### PR TITLE
Seed Tensorfield HTS implementation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+__pycache__/
+*.py[cod]
+.pytest_cache/
+*.egg-info/

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,9 @@
+cff-version: 1.2.0
+title: Tensorfield-HTS
+message: If you use this software, please cite it.
+authors:
+  - family-names: YourLastName
+    given-names: YourFirstName
+    affiliation: Tensorfield Lab
+version: 0.1.0
+date-released: 2025-10-03

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2025 Juan Mejia
+Copyright (c) 2025 Tensorfield-HTS Contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -1,34 +1,40 @@
-# HTS-ViT: Hypergraph Tensor Supersystem for Vision Transformers
+# Tensorfield-HTS
 
-## Overview
-HTS-ViT (Hypergraph Tensor Supersystem - Vision Transformer) is an advanced AI framework designed to optimize Vision Transformers (ViTs) using hypergraph-tensor representations and dynamic, self-optimizing computation paths. This project aims to bridge the gap between static GPU pipelines and evolving tensor structures, enabling efficient, adaptive computation.
+Hypergraph Tensor Supersystems (HTS) + HTS‑ViT + CDMNs + Datatropisms.
 
-## Vision
-HTS-ViT is the software counterpart to GPU hardware acceleration, transforming AI processing units into adaptive, context-aware systems. This framework introduces hypergraph-tensor representation, self-optimizing data flow, and datatropisms as software-level optimization.
+**Why**: Move beyond vector‑centric pipelines. Embed tensors on hypergraphs/manifolds; let attention and flows respect geometry & topology. Teach linear algebra geometrically/computationally for real systems (AI/ML/LLMs).
 
-## Key Features
-- **Hypergraph-Tensor Representation**: Encodes multi-scale image features and hierarchical relational learning.
-- **Self-Optimizing Computation Paths**: Adapts computations dynamically based on input data.
-- **Datatropisms**: Software-level optimizations for feature refinement and alignment.
+## Key Concepts (short)
+- **Tensorfield**: dynamic tensor field \(\mathcal{T}\) on nodes/patches of a hypergraph \(H=(V,E)\) and (optionally) a manifold.
+- **Hypergraph Laplacian**: spatial/relational prior \(\Delta_H\) coupling patches.
+- **Datatropisms**: forces guiding evolution: gradient‑, entrop‑, correlat‑, anisotrop‑isms.
+- **Flows**: convolution ⇄ deconvolution; dissemination ⇄ insemination.
+- **Riemann Manifold Puncture**: bridge from hypersphere representations to reality via metric projections & Sobolev inner products.
+- **HTS‑ViT**: self‑attention operating inside the tensorfield, modulated by \(H\) and tropisms.
 
-## Why HTS-ViT?
-- **Adaptive Feature Scaling**: Dynamically scales feature importance, avoiding unnecessary computations.
-- **Hierarchical Representation Learning**: Connects related features dynamically, replacing rigid hierarchical layers.
-- **Efficient Computation**: Replaces brute-force FLOP scaling with efficient, adaptive computation.
+## Install
+```bash
+pip install -e .
+```
 
-## The Future of AI Computation
-HTS-ViT is not just another deep learning framework; it is the missing link in the GPU-software co-evolution. It paves the way for a future where software and hardware collaborate seamlessly to produce intelligence that is truly self-organizing, context-sensitive, and continuously evolving.
+## Quickstart
 
-## Getting Started
-1. Clone the repository
-   ```bash
-   git clone https://github.com/yourusername/HTS-ViT.git
-   ```
-2. Follow the setup instructions in the [Installation Guide](docs/INSTALL.md)
-3. Explore the [Examples](examples) to see HTS-ViT in action
+```python
+from tensorfield import Hypergraph, hts_block, datatropic_step
+import numpy as np
 
-## Contributing
-We welcome contributions from the community. Please read our [Contributing Guide](CONTRIBUTING.md) to get started.
+# Toy tokens on 5 patches
+T = np.random.randn(5, 32)
+H = Hypergraph(n=5, hyperedges=[[0,1,2],[2,3,4]])
 
-## License
-This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.
+for _ in range(3):
+    T = hts_block(T, H)              # HTS attention + hypergraph prior
+    T = datatropic_step(T, H)        # gradient/entropy/correlation/anisotropy forces
+print(T.shape)  # (5, 32)
+```
+
+## Papers/Notes
+
+* See `docs/` for foundations and API.
+* `examples/` for runnable demos.
+```

--- a/docs/01_foundations.md
+++ b/docs/01_foundations.md
@@ -1,0 +1,13 @@
+# Foundations: Tensorfield & HTS
+
+A tensorfield \(\mathcal{T} = [T_1,\dots,T_N]\) lives on hypergraph nodes (image patches, agents, etc.).
+
+**Hypergraph Laplacian (Zhou):**
+\[L = I - D_v^{-1/2} H W D_e^{-1} H^\top D_v^{-1/2}\]
+
+**HTS Attention:**
+\[ V^{\wedge}_{\mathrm{Att}}(T) = \mathrm{softmax}\big(\tfrac{TW_Q (TW_K)^\top}{\sqrt d}\big)\, TW_V \]
+
+**Evolution (datatropic PDE, discrete step):**
+\[\Delta T = \lambda_1\,\nabla_{\text{Att}} + \lambda_2\,\rho + \lambda_3\,F_{\text{Edge}} + \dots\]
+We implement practical proxies for each term in `datatropisms.py`.

--- a/docs/02_datatropisms.md
+++ b/docs/02_datatropisms.md
@@ -1,0 +1,8 @@
+# Datatropisms
+
+- **Gradientropism**: pull tokens to attention centroids.
+- **Entropism**: increase variability (repel similar tokens).
+- **Correlatropism**: align with principal correlation modes.
+- **Anisotropism**: drift along an external bias.
+
+API: `datatropic_step(T, G=None, strength=dict)`

--- a/docs/03_systemic_transformations.md
+++ b/docs/03_systemic_transformations.md
@@ -1,0 +1,7 @@
+# Systemic Dynamical Transformations
+
+**Convolution ⇄ Deconvolution** on hypersphere (cosine/geodesic kernel).
+
+**Dissemination ⇄ Insemination** across hyperedges (broadcast average vs targeted insert).
+
+These form expansion/contraction flows of information.

--- a/docs/04_iterative_puncture.md
+++ b/docs/04_iterative_puncture.md
@@ -1,0 +1,13 @@
+# Iteratives & the Riemann Manifold Puncture
+
+**Harmonic Convergence**: iterative dimensional calibration.
+
+**Sobolev inner product (proxy):**
+\[ \langle F, G \rangle_{W^{k,2}} \approx \sum_{i=0}^k \langle \Delta^i F, \Delta^i G \rangle \]
+
+**Riemann dot** with metric \(g\): \(\langle P(T_i), P(T_j)\rangle_M = g(P(T_i),P(T_j))\).
+
+**Spherical projection radius:**
+\[ r = \sqrt{\langle P(T_i),P(T_i)\rangle_M - \langle P(T_i),P(T_j)\rangle_M } \]
+
+See `puncture.py` for programmatic counterparts.

--- a/docs/05_hts_vit.md
+++ b/docs/05_hts_vit.md
@@ -1,0 +1,8 @@
+# HTS‑ViT
+
+Self‑attention over tensorfields + hypergraph priors + datatropisms + geodesic conv.
+
+**One block:** `hts_vit_step(T, G)`
+
+Use for multi‑scale perception by varying hyperedge scopes (local ↔ global). Bracket notation:
+\[\langle T_{\text{Vision}} | V^{\wedge}_{\text{Attention}} | T_{\text{Vision}}\rangle\]

--- a/docs/06_api_reference.md
+++ b/docs/06_api_reference.md
@@ -1,0 +1,17 @@
+# API Reference (short)
+
+- `Hypergraph(n, hyperedges, weights=None)`
+- `hypergraph_laplacian(G, variant='zhou') -> np.ndarray`
+- `hts_attention(T, Wq, Wk, Wv, G=None, laplacian_strength=0.0)`
+- `hts_block(T, G=None, laplacian_strength=0.2)`
+- `datatropic_step(T, G=None, strength=None)`
+- `geodesic_convolution(T, sigma=0.8)`
+- `dissemination(T, hyperedges, weight=0.5)`
+- `deconvolution(T, alpha=0.2)`
+- `insemination(T, inserts)`
+- `sobolev_inner(F,G,order=1)`
+- `project_to_manifold(T, P=None)`
+- `riemann_dot(X,Y,G=None)`
+- `spherical_radius(Pi,Pj,metric=None)`
+- `hts_vit_step(T, G=None)`
+- `HTSRenderer.render_interactive(E_t=0.0)`

--- a/examples/01_quickstart.py
+++ b/examples/01_quickstart.py
@@ -1,0 +1,11 @@
+import numpy as np
+from tensorfield import Hypergraph, hts_block, datatropic_step
+
+N, d = 6, 16
+T = np.random.randn(N, d)
+G = Hypergraph(n=N, hyperedges=[[0,1,2],[2,3,4,5]])
+
+for it in range(5):
+    T = hts_block(T, G)
+    T = datatropic_step(T, G)
+print("Final shape:", T.shape)

--- a/examples/02_hts_vit_minidemo.py
+++ b/examples/02_hts_vit_minidemo.py
@@ -1,0 +1,11 @@
+import numpy as np
+from tensorfield import Hypergraph
+from tensorfield.hts_vit import hts_vit_step
+
+N, d = 8, 32
+T = np.random.randn(N, d)
+G = Hypergraph(n=N, hyperedges=[[0,1,2],[2,3,4],[4,5,6,7]])
+
+for _ in range(4):
+    T = hts_vit_step(T, G)
+print(T.mean(), T.std())

--- a/examples/03_renderer_demo.py
+++ b/examples/03_renderer_demo.py
@@ -1,0 +1,3 @@
+from tensorfield.renderer import HTSRenderer
+fig = HTSRenderer().render_interactive(E_t=0.8)
+fig.show()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,23 @@
+[build-system]
+requires = ["setuptools>=61.0"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "tensorfield-hts"
+version = "0.1.0"
+description = "Hypergraph Tensor Supersystems: HTS, HTS‑ViT, CDMNs, Datatropisms"
+readme = "README.md"
+authors = [{name = "Tensorfield Lab"}]
+requires-python = ">=3.9"
+dependencies = [
+  "numpy>=1.23",
+  "networkx>=3.0",
+  "scipy>=1.9",
+  "plotly>=5.15",
+]
+
+[tool.setuptools]
+package-dir = {"" = "src"}
+
+[tool.setuptools.packages.find]
+where = ["src"]

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,16 @@
+[metadata]
+name = tensorfield-hts
+version = 0.1.0
+
+[options]
+packages = find:
+package_dir = =src
+python_requires = >=3.9
+install_requires =
+    numpy>=1.23
+    networkx>=3.0
+    scipy>=1.9
+    plotly>=5.15
+
+[options.packages.find]
+where = src

--- a/src/tensorfield/__init__.py
+++ b/src/tensorfield/__init__.py
@@ -1,0 +1,5 @@
+from .hypergraph import Hypergraph, hypergraph_laplacian
+from .attention import hts_attention, hts_block
+from .datatropisms import datatropic_step
+from .cdmn import geodesic_convolution, dissemination, deconvolution, insemination
+from .puncture import sobolev_inner, riemann_dot, project_to_manifold

--- a/src/tensorfield/attention.py
+++ b/src/tensorfield/attention.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+import numpy as np
+from .hypergraph import Hypergraph, hypergraph_laplacian
+
+
+def hts_attention(T: np.ndarray, Wq: np.ndarray, Wk: np.ndarray, Wv: np.ndarray,
+                  G: Hypergraph | None = None, laplacian_strength: float = 0.0) -> np.ndarray:
+    """Scaled dot-product attention with optional hypergraph geometric prior.
+
+    T: (N, d) tokens; W* : (d, d)
+    Returns: (N, d)
+    """
+    Q = T @ Wq
+    K = T @ Wk
+    V = T @ Wv
+    dk = K.shape[1]
+    logits = (Q @ K.T) / np.sqrt(dk)
+    if G is not None and laplacian_strength > 0:
+        L = hypergraph_laplacian(G, variant="zhou")  # (N,N)
+        # Encourage attention along hypergraph relations; subtract Laplacian energy
+        logits = logits - laplacian_strength * L
+    # softmax row-wise
+    logits = logits - logits.max(axis=1, keepdims=True)
+    A = np.exp(logits)
+    A /= (A.sum(axis=1, keepdims=True) + 1e-8)
+    return A @ V
+
+
+def hts_block(T: np.ndarray, G: Hypergraph | None = None, laplacian_strength: float = 0.2,
+              seed: int | None = 0) -> np.ndarray:
+    """One HTS‑ViT style block: attention over tensorfield with hypergraph prior + residual.
+    Weights are randomly initialised for didactic demo.
+    """
+    rng = np.random.default_rng(seed)
+    d = T.shape[1]
+    Wq = rng.normal(scale=0.5, size=(d, d))
+    Wk = rng.normal(scale=0.5, size=(d, d))
+    Wv = rng.normal(scale=0.5, size=(d, d))
+    att = hts_attention(T, Wq, Wk, Wv, G, laplacian_strength)
+    return T + att  # simple residual

--- a/src/tensorfield/cdmn.py
+++ b/src/tensorfield/cdmn.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+import numpy as np
+
+# --- Convolution on (approx) hypersphere via cosine kernel ---
+
+def geodesic_convolution(T: np.ndarray, sigma: float = 0.8) -> np.ndarray:
+    """Geodesic-style convolution using cosine distances as geodesics on S^{d-1}.
+    T: (N, d)
+    """
+    X = T / (np.linalg.norm(T, axis=1, keepdims=True) + 1e-8)
+    cos = X @ X.T
+    theta = np.arccos(np.clip(cos, -1.0, 1.0))
+    K = np.exp(-(theta**2) / (2 * sigma**2))
+    K /= (K.sum(axis=1, keepdims=True) + 1e-8)
+    return K @ T
+
+# --- Dissemination & its inverse operations ---
+
+def dissemination(T: np.ndarray, hyperedges: list[list[int]], weight: float = 0.5) -> np.ndarray:
+    """Spread tensor info by averaging over hyperedges (simple broadcast)."""
+    X = T.copy()
+    for e in hyperedges:
+        avg = T[e, :].mean(axis=0, keepdims=True)
+        X[e, :] = (1 - weight) * T[e, :] + weight * avg
+    return X
+
+
+def deconvolution(T: np.ndarray, alpha: float = 0.2) -> np.ndarray:
+    """Sharpen signals (unsharp masking style) as a deconvolution proxy."""
+    blurred = geodesic_convolution(T)
+    return T + alpha * (T - blurred)
+
+
+def insemination(T: np.ndarray, inserts: dict[int, np.ndarray]) -> np.ndarray:
+    """Targeted insertion of token values at specified indices."""
+    X = T.copy()
+    for idx, vec in inserts.items():
+        X[idx, :] = vec
+    return X

--- a/src/tensorfield/datatropisms.py
+++ b/src/tensorfield/datatropisms.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+import numpy as np
+from .hypergraph import Hypergraph, hypergraph_laplacian
+
+
+def _row_norm(x: np.ndarray, eps: float = 1e-8) -> np.ndarray:
+    n = np.linalg.norm(x, axis=1, keepdims=True)
+    return x / (n + eps)
+
+
+def gradientropism(T: np.ndarray, A: np.ndarray, strength: float = 0.5) -> np.ndarray:
+    """Pull tokens toward high-attention centroids (discrete attention-gradient proxy).
+    A: (N,N) attention matrix (row-stochastic). Returns ΔT.
+    """
+    centroid = A @ T
+    return strength * (centroid - T)
+
+
+def entropism(T: np.ndarray, strength: float = 0.05) -> np.ndarray:
+    """Spread features to increase diversity: push rows apart (repulsion). Returns ΔT."""
+    X = _row_norm(T)
+    S = X @ X.T  # cos sim
+    rep = (S * 1.0 - np.eye(T.shape[0])) @ T  # push away from similar
+    return -strength * rep / T.shape[0]
+
+
+def correlatropism(T: np.ndarray, strength: float = 0.2) -> np.ndarray:
+    """Align with principal correlation directions (PCA-like). Returns ΔT."""
+    T0 = T - T.mean(axis=0, keepdims=True)
+    C = (T0.T @ T0) / max(1, T.shape[0]-1)
+    # Project onto top-k eigens (k = min(4, d))
+    w, V = np.linalg.eigh(C)
+    idx = np.argsort(w)[::-1]
+    V_top = V[:, idx[: min(4, V.shape[1])]]
+    proj = (T0 @ V_top) @ V_top.T
+    return strength * (proj - T0)
+
+
+def anisotropism(T: np.ndarray, direction: np.ndarray | None = None, strength: float = 0.1) -> np.ndarray:
+    """Directional drift along an external bias vector in feature space."""
+    if direction is None:
+        direction = np.ones(T.shape[1])
+    direction = direction / (np.linalg.norm(direction) + 1e-8)
+    return strength * (T @ np.outer(direction, direction) - T * 0.0)
+
+
+def datatropic_step(T: np.ndarray, G: Hypergraph | None = None, strength: dict | None = None) -> np.ndarray:
+    """Apply combined datatropic evolution once.
+    strength: optional dict of coefficients.
+    """
+    st = {"grad": 0.6, "entr": 0.03, "corr": 0.15, "anis": 0.1}
+    if strength: st.update(strength)
+    # lightweight attention proxy for gradientropism
+    QK = T @ T.T / np.sqrt(T.shape[1])
+    QK = QK - QK.max(axis=1, keepdims=True)
+    A = np.exp(QK); A /= (A.sum(axis=1, keepdims=True) + 1e-8)
+    dT = (
+        st["grad"] * gradientropism(T, A, strength=1.0)
+        + st["entr"] * entropism(T)
+        + st["corr"] * correlatropism(T)
+        + st["anis"] * anisotropism(T)
+    )
+    # Optional geometric smoothing along hypergraph
+    if G is not None:
+        L = hypergraph_laplacian(G)
+        dT = dT - 0.05 * (L @ T)
+    return T + dT

--- a/src/tensorfield/hts_vit.py
+++ b/src/tensorfield/hts_vit.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+import numpy as np
+from .attention import hts_attention
+from .hypergraph import Hypergraph
+from .cdmn import geodesic_convolution, dissemination, deconvolution, insemination
+from .datatropisms import datatropic_step
+
+
+def hts_vit_step(T: np.ndarray, G: Hypergraph | None = None, seed: int | None = 0) -> np.ndarray:
+    """One composite HTS‑ViT step: attention ⟶ geodesic conv ⟶ dissemination ⟶ tropisms."""
+    T1 = hts_attention(T, *(np.eye(T.shape[1]),)*3, G, laplacian_strength=0.2)
+    T2 = geodesic_convolution(T1)
+    if G is not None:
+        T3 = dissemination(T2, G.hyperedges, weight=0.4)
+    else:
+        T3 = T2
+    T4 = datatropic_step(T3, G)
+    return T4

--- a/src/tensorfield/hypergraph.py
+++ b/src/tensorfield/hypergraph.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+import numpy as np
+from dataclasses import dataclass
+
+@dataclass
+class Hypergraph:
+    n: int
+    hyperedges: list[list[int]]
+    weights: list[float] | None = None
+
+    def incidence(self) -> np.ndarray:
+        m = len(self.hyperedges)
+        H = np.zeros((self.n, m), dtype=float)
+        for j, e in enumerate(self.hyperedges):
+            for v in e:
+                H[v, j] = 1.0
+        return H
+
+    def weight_matrix(self) -> np.ndarray:
+        m = len(self.hyperedges)
+        w = np.ones(m) if self.weights is None else np.asarray(self.weights, dtype=float)
+        return np.diag(w)
+
+
+def hypergraph_laplacian(G: Hypergraph, variant: str = "zhou") -> np.ndarray:
+    """Return a hypergraph Laplacian.
+
+    * zhou: L = I - Dv^{-1/2} H W De^{-1} H^T Dv^{-1/2}
+    * simple: Δ_H = Dv^{-1} H W H^T Dv^{-1}
+    """
+    H = G.incidence()
+    W = G.weight_matrix()
+    dv = H @ W @ np.ones((H.shape[1], 1))  # vertex degree
+    Dv = np.diagflat(dv.ravel() + 1e-8)
+    if variant == "zhou":
+        De = np.diag((H.sum(axis=0) + 1e-8))  # hyperedge size diag
+        Dv_mhalf = np.linalg.inv(np.sqrt(Dv))
+        De_inv = np.linalg.inv(De)
+        I = np.eye(G.n)
+        L = I - Dv_mhalf @ H @ W @ De_inv @ H.T @ Dv_mhalf
+        return L
+    else:
+        Dv_inv = np.linalg.inv(Dv)
+        return Dv_inv @ H @ W @ H.T @ Dv_inv

--- a/src/tensorfield/puncture.py
+++ b/src/tensorfield/puncture.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+import numpy as np
+
+# --- Sobolev-like inner product (discrete proxy) ---
+
+def sobolev_inner(F: np.ndarray, G: np.ndarray, order: int = 1) -> float:
+    """Discrete Sobolev inner product W^{k,2} on sequences of tokens (proxy).
+    Treat rows as samples; finite-difference along sample index.
+    """
+    assert F.shape == G.shape
+    base = float(np.sum(F * G))
+    acc = base
+    dF, dG = F.copy(), G.copy()
+    for _ in range(order):
+        dF = np.diff(dF, axis=0, prepend=dF[:1])
+        dG = np.diff(dG, axis=0, prepend=dG[:1])
+        acc += float(np.sum(dF * dG))
+    return acc
+
+# --- Riemann manifold projection & metric dot ---
+
+def project_to_manifold(T: np.ndarray, P: np.ndarray | None = None) -> np.ndarray:
+    """Linear projection to a tangent chart: Y = T @ P (default: identity)."""
+    if P is None:
+        return T
+    return T @ P
+
+
+def riemann_dot(X: np.ndarray, Y: np.ndarray, G: np.ndarray | None = None) -> float:
+    """Dot using metric tensor G (positive definite)."""
+    if G is None:
+        return float(np.sum(X * Y))
+    return float(np.sum((X @ G) * Y))
+
+
+def spherical_radius(Pi: np.ndarray, Pj: np.ndarray, metric: np.ndarray | None = None) -> float:
+    """Confidence radius r = sqrt(<Pi,Pi> - <Pi,Pj>)."""
+    a = riemann_dot(Pi, Pi, metric)
+    b = riemann_dot(Pi, Pj, metric)
+    return float(np.sqrt(max(0.0, a - b)))

--- a/src/tensorfield/renderer.py
+++ b/src/tensorfield/renderer.py
@@ -1,0 +1,54 @@
+# Adapted from the interactive HTSRenderer prototype (Plotly + NetworkX).
+import numpy as np
+import plotly.graph_objects as go
+import networkx as nx
+
+class HTSRenderer:
+    def __init__(self, alpha=(2.0,0.5,0.3), beta=(1.5,0.7), theta=1.0):
+        self.a0, self.a1, self.a2 = alpha
+        self.b0, self.b1 = beta
+        self.theta = theta
+        self.nodos = ["Qd", "Qs", "P", "E"]
+        self.pos = {"Qd": (0, 1, 0), "Qs": (0, -1, 0), "P": (1.2, 0, 0), "E": (-1.2, 0, 0)}
+        self._build_hypergraph()
+
+    def equilibrio_log_price(self, E_t):
+        return (self.a0 - self.b0 + self.a2 * E_t) / (self.a1 + self.b1)
+
+    def estado_mercado(self, E_t):
+        lnP = self.equilibrio_log_price(E_t)
+        lnQd = self.a0 - self.a1 * lnP + self.a2 * E_t
+        lnQs = self.b0 + self.b1 * lnP
+        return np.array([lnQd, lnQs, lnP])
+
+    def operador_V(self, psi, E_t):
+        return psi + self.theta * (self.estado_mercado(E_t) - psi)
+
+    def _build_hypergraph(self):
+        G = nx.DiGraph()
+        G.add_nodes_from(self.nodos)
+        G.add_edge("E", "Qd", weight=self.a2)
+        G.add_edge("P", "Qd", weight=-self.a1)
+        G.add_edge("P", "Qs", weight=self.b1)
+        self.hypergraph = G
+
+    def render_interactive(self, E_t=0.0):
+        psi0 = self.estado_mercado(0.0)
+        psi1 = self.operador_V(psi0, E_t)
+        fig = go.Figure()
+        for node, (x, y, z) in self.pos.items():
+            fig.add_trace(go.Scatter3d(x=[x], y=[y], z=[z], mode='markers+text',
+                                       marker=dict(size=10), text=[node], textposition="top center"))
+        for u, v, d in self.hypergraph.edges(data=True):
+            x0, y0, z0 = self.pos[u]; x1, y1, z1 = self.pos[v]
+            fig.add_trace(go.Scatter3d(x=[x0, x1], y=[y0, y1], z=[z0, z1], mode='lines',
+                                       line=dict(width=2, color='gray'), name=f"{u}→{v} ({d['weight']:.2f})"))
+        for i, var in enumerate(["Qd", "Qs", "P"]):
+            _, y, _ = self.pos[var]
+            z0, z1 = psi0[i], psi1[i]
+            fig.add_trace(go.Scatter3d(x=[1.5, 1.5], y=[y, y], z=[z0, z1], mode='lines+markers',
+                                       marker=dict(size=4), line=dict(color='red', width=4), name=f'{var}'))
+        fig.update_layout(title=f"HTS Flow – Externalidad E_t = {E_t:.2f}",
+                          scene=dict(xaxis_title='Estructura', yaxis_title='Variable', zaxis_title='Log-valor'),
+                          margin=dict(l=0, r=0, t=50, b=0), height=600)
+        return fig

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -1,0 +1,10 @@
+import numpy as np
+from tensorfield import Hypergraph, hts_block, datatropic_step, geodesic_convolution
+
+def test_pipeline_runs():
+    T = np.random.randn(5, 8)
+    G = Hypergraph(5, [[0,1,2],[2,3,4]])
+    T = hts_block(T, G)
+    T = geodesic_convolution(T)
+    T = datatropic_step(T, G)
+    assert T.shape == (5, 8)

--- a/wolfram/dissemination_operator.wl
+++ b/wolfram/dissemination_operator.wl
@@ -1,0 +1,11 @@
+(* Dissemination operator prototype *)
+ClearAll[disseminationStep]
+disseminationStep[tensor_, hyperedges_, weight_:0.5] := Module[{X = tensor},
+  Do[
+    Module[{avg = Mean[X[[edge]]]},
+      X[[edge]] = (1 - weight) X[[edge]] + weight avg
+    ],
+    {edge, hyperedges}
+  ];
+  X
+]

--- a/wolfram/geodesic_convolution.wl
+++ b/wolfram/geodesic_convolution.wl
@@ -1,0 +1,11 @@
+(* Geodesic convolution sketch in WL *)
+latentFeatures[data_] := Normalize /@ data;
+geodesicDistance[Ti_, Tj_, r_:1] := r ArcCos[Clip[Ti.Tj, {-1,1}]];
+adaptiveKernel[d_, sigma_:0.8] := Exp[-(d^2)/(2 sigma^2)];
+
+gConvolve[tensorField_, sigma_:0.8] := Module[{X, K},
+  X = latentFeatures[tensorField];
+  K = Table[ adaptiveKernel[ geodesicDistance[X[[i]], X[[j]]], sigma], {i, Length[X]}, {j, Length[X]} ];
+  K = K/Total[K, {2}];
+  K.tensorField
+]

--- a/wolfram/propagate_tensorfield.wl
+++ b/wolfram/propagate_tensorfield.wl
@@ -1,0 +1,9 @@
+(* Tensorfield propagation sketch *)
+ClearAll[propagateTensorfield]
+propagateTensorfield[tensor_, hypergraph_, steps_:3] := Module[{T = tensor},
+  Do[
+    T = gConvolve[T, 0.8];
+    T = disseminationStep[T, hypergraph, 0.4];
+  , {steps}];
+  T
+]


### PR DESCRIPTION
## Summary
- replace the placeholder documentation with the Tensorfield-HTS README and metadata
- add the tensorfield Python package with hypergraph, attention, datatropism, and renderer modules
- add docs, examples, Wolfram sketches, and a smoke test covering the basic tensorfield pipeline

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68e08cbf01e08331ae5c135bfedfbe06